### PR TITLE
Handling multiple answer values

### DIFF
--- a/src/SFA.DAS.QnA.Api.Types/Page/Answer.cs
+++ b/src/SFA.DAS.QnA.Api.Types/Page/Answer.cs
@@ -3,6 +3,6 @@ namespace SFA.DAS.QnA.Api.Types.Page
     public class Answer
     {
         public string QuestionId { get; set; }
-        public string Value { get; set; }
+        public string[] Value { get; set; }
     }
 }

--- a/src/SFA.DAS.QnA.Api.Types/Page/Condition.cs
+++ b/src/SFA.DAS.QnA.Api.Types/Page/Condition.cs
@@ -5,5 +5,6 @@ namespace SFA.DAS.QnA.Api.Types.Page
         public string QuestionId { get; set; }
         public string QuestionTag { get; set; }
         public string MustEqual { get; set; }
+        public string Contains { get; set; }
     }
 }

--- a/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SetPageAnswersTests/When_a_branching_condition_is_changed.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SetPageAnswersTests/When_a_branching_condition_is_changed.cs
@@ -18,12 +18,12 @@ namespace SFA.DAS.QnA.Application.UnitTests.CommandsTests.SetPageAnswersTests
         {
             await Handler.Handle(new SetPageAnswersRequest(ApplicationId, SectionId, "1", new List<Answer>
             {
-                new Answer() {QuestionId = "Q1", Value = "Yes"}
+                new Answer() {QuestionId = "Q1", Value = new []{ "Yes" }}
             }), CancellationToken.None);
             
             await Handler.Handle(new SetPageAnswersRequest(ApplicationId, SectionId, "1", new List<Answer>
             {
-                new Answer() {QuestionId = "Q1", Value = "No"}
+                new Answer() {QuestionId = "Q1", Value = new []{ "No"}}
             }), CancellationToken.None);
             
             var updatedSection = await DataContext.ApplicationSections.SingleAsync();
@@ -45,18 +45,19 @@ namespace SFA.DAS.QnA.Application.UnitTests.CommandsTests.SetPageAnswersTests
         {
             await Handler.Handle(new SetPageAnswersRequest(ApplicationId, SectionId, "1", new List<Answer>
             {
-                new Answer() {QuestionId = "Q1", Value = "Yes"}
+                new Answer() {QuestionId = "Q1", Value = new []{"Yes"}}
             }), CancellationToken.None);
             
             await Handler.Handle(new SetPageAnswersRequest(ApplicationId, SectionId, "2", new List<Answer>
             {
-                new Answer() {QuestionId = "Q2", Value = "No"}
+                new Answer() {QuestionId = "Q2", Value =new []{ "No"}}
             }), CancellationToken.None);
             
             await Handler.Handle(new SetPageAnswersRequest(ApplicationId, SectionId, "2", new List<Answer>
             {
-                new Answer() {QuestionId = "Q2", Value = "Yes"}
-            }), CancellationToken.None);
+                new Answer() {QuestionId = "Q2", Value = new []{"Yes"}
+            }
+    }), CancellationToken.None);
             
             var updatedSection = await DataContext.ApplicationSections.SingleAsync();
             

--- a/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SetPageAnswersTests/When_a_branching_condition_is_question_tag.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SetPageAnswersTests/When_a_branching_condition_is_question_tag.cs
@@ -21,7 +21,7 @@
 
             var response = await Handler.Handle(new SetPageAnswersRequest(applicationId, sectionId, "100", new List<Answer>
             {
-                new Answer() {QuestionId = "Q1", Value = "Yes"}
+                new Answer() {QuestionId = "Q1", Value = new []{"Yes"}}
             }), CancellationToken.None);
 
             response.Value.NextActionId.Should().Be("102");
@@ -36,7 +36,7 @@
 
             var response = await Handler.Handle(new SetPageAnswersRequest(applicationId, sectionId, "100", new List<Answer>
             {
-                new Answer() {QuestionId = "Q1", Value = "Yes"}
+                new Answer() {QuestionId = "Q1", Value = new []{"Yes"}}
             }), CancellationToken.None);
 
             response.Value.NextActionId.Should().Be("101");

--- a/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SetPageAnswersTests/When_multiple_values_submitted_for_an_answer.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SetPageAnswersTests/When_multiple_values_submitted_for_an_answer.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json.Linq;
+using NSubstitute;
+using NUnit.Framework;
+using SFA.DAS.QnA.Api.Types.Page;
+using SFA.DAS.QnA.Application.Commands;
+using SFA.DAS.QnA.Application.Commands.SetPageAnswers;
+using SFA.DAS.QnA.Data.Entities;
+
+namespace SFA.DAS.QnA.Application.UnitTests.CommandsTests.SetPageAnswersTests
+{
+    [TestFixture]
+    public class When_multiple_values_submitted_for_an_answer
+    {
+        [Test]
+        public async Task Then_ApplicationData_is_updated_with_array_of_values()
+        {
+            var applicationId = Guid.NewGuid();
+            var sectionId = Guid.NewGuid();
+
+            var dataContext = DataContextHelpers.GetInMemoryDataContext();
+
+            await dataContext.Applications.AddAsync(new Data.Entities.Application(){Id = applicationId, ApplicationData = "{}"});
+            
+            await dataContext.ApplicationSections.AddAsync(new ApplicationSection()
+            {
+                ApplicationId = applicationId, Id = sectionId, 
+                QnAData = new QnAData()
+                {
+                    Pages = new List<Page>()
+                    {
+                        new Page()
+                        {
+                            PageId = "1",
+                            Questions = new List<Question>{new Question(){QuestionId = "Q1", Input = new Input(), QuestionTag = "q1tag"}},
+                            PageOfAnswers = new List<PageOfAnswers>(),
+                            Next = new List<Next>
+                            {
+                                new Next(){Action = "NextPage", ReturnId = "2", Conditions = new List<Condition>()}
+                            },
+                            Active = true
+                        },
+                    }
+                }
+            });
+            
+            await dataContext.SaveChangesAsync();
+            
+            var answerValidator = Substitute.For<IAnswerValidator>();
+
+            var answers = new List<Answer>()
+            {
+                new Answer(){QuestionId = "Q1", Value = new []{"Blue", "Red"}}
+            };
+
+            answerValidator.Validate(answers, Arg.Any<Page>()).Returns(new List<KeyValuePair<string, string>>());
+            
+            var setPageAnswersHandler = new SetPageAnswersHandler(dataContext, answerValidator);
+
+            
+            await setPageAnswersHandler.Handle(new SetPageAnswersRequest(applicationId, sectionId, "1", answers), new CancellationToken());
+
+
+            var application = dataContext.Applications.Single();
+
+            application.ApplicationData.Should().NotBeEmpty();
+
+            var appData = JObject.Parse(application.ApplicationData);
+
+            var applicationQiTag = appData["q1tag"].Value<JArray>();
+
+            applicationQiTag.Count.Should().Be(2);
+            applicationQiTag[0].Value<string>().Should().Be("Blue");
+            applicationQiTag[1].Value<string>().Should().Be("Red");
+        }
+    }
+}

--- a/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SetPageAnswersTests/When_radio_condition_redirects_to_new_branch.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SetPageAnswersTests/When_radio_condition_redirects_to_new_branch.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.CommandsTests.SetPageAnswersTests
         {
             await Handler.Handle(new SetPageAnswersRequest(ApplicationId, SectionId, "1", new List<Answer>
             {
-                new Answer() {QuestionId = "Q1", Value = "Yes"}
+                new Answer() {QuestionId = "Q1", Value = new []{"Yes"}}
             }), CancellationToken.None);
 
             var updatedSection = await DataContext.ApplicationSections.SingleAsync();
@@ -39,7 +39,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.CommandsTests.SetPageAnswersTests
         {
             await Handler.Handle(new SetPageAnswersRequest(ApplicationId, SectionId, "1", new List<Answer>
             {
-                new Answer() {QuestionId = "Q1", Value = "No"}
+                new Answer() {QuestionId = "Q1", Value =new []{ "No"}}
             }), CancellationToken.None);
 
             var updatedSection = await DataContext.ApplicationSections.SingleAsync();
@@ -61,12 +61,12 @@ namespace SFA.DAS.QnA.Application.UnitTests.CommandsTests.SetPageAnswersTests
         {
             await Handler.Handle(new SetPageAnswersRequest(ApplicationId, SectionId, "1", new List<Answer>
             {
-                new Answer() {QuestionId = "Q1", Value = "Yes"}
+                new Answer() {QuestionId = "Q1", Value = new []{"Yes"}}
             }), CancellationToken.None);
             
             await Handler.Handle(new SetPageAnswersRequest(ApplicationId, SectionId, "2", new List<Answer>
             {
-                new Answer() {QuestionId = "Q2", Value = "Yes"}
+                new Answer() {QuestionId = "Q2", Value =new []{ "Yes"}}
             }), CancellationToken.None);
 
             var updatedSection = await DataContext.ApplicationSections.SingleAsync();
@@ -88,12 +88,12 @@ namespace SFA.DAS.QnA.Application.UnitTests.CommandsTests.SetPageAnswersTests
         {
             await Handler.Handle(new SetPageAnswersRequest(ApplicationId, SectionId, "1", new List<Answer>
             {
-                new Answer() {QuestionId = "Q1", Value = "Yes"}
+                new Answer() {QuestionId = "Q1", Value =new []{ "Yes"}}
             }), CancellationToken.None);
             
             await Handler.Handle(new SetPageAnswersRequest(ApplicationId, SectionId, "2", new List<Answer>
             {
-                new Answer() {QuestionId = "Q2", Value = "No"}
+                new Answer() {QuestionId = "Q2", Value = new []{"No"}}
             }), CancellationToken.None);
 
             var updatedSection = await DataContext.ApplicationSections.SingleAsync();

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/AddressValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/AddressValidatorTests/When_Validate_Called.cs
@@ -26,7 +26,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.AddressValidatorTests
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }
@@ -49,7 +49,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.AddressValidatorTests
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }
@@ -72,7 +72,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.AddressValidatorTests
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value =new []{ input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/ComplexRadioTypeValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/ComplexRadioTypeValidatorTests/When_Validate_Called.cs
@@ -26,7 +26,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.ComplexRadioTypeValidator
 
             var options = new List<Option> { new Option { Value = "yes" }, new Option { Value = "no" } };
             var question = new Question { QuestionId = "Q1", Input = new Input { Options = options } };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/DateNotInFutureValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/DateNotInFutureValidatorTests/When_Validate_Called.cs
@@ -25,7 +25,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.DateNotInFutureValidatorT
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/DateTypeValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/DateTypeValidatorTests/When_Validate_Called.cs
@@ -25,7 +25,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.DateTypeValidatorTests
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/DateValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/DateValidatorTests/When_Validate_Called.cs
@@ -25,7 +25,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.DateValidatorTests
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/EmailTypeValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/EmailTypeValidatorTests/When_Validate_Called.cs
@@ -30,7 +30,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.EmailTypeValidatorTests
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/EmailValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/EmailValidatorTests/When_Validate_Called.cs
@@ -31,7 +31,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.EmailValidatorTests
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/FileTypeValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/FileTypeValidatorTests/When_Validate_Called.cs
@@ -28,7 +28,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.FileTypeValidatorTests
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/MaxLengthValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/MaxLengthValidatorTests/When_Validate_Called.cs
@@ -26,7 +26,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.MaxLengthValidatorTests
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/MaxWordCountValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/MaxWordCountValidatorTests/When_Validate_Called.cs
@@ -26,7 +26,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.MaxWordCountValidatorTest
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/MinLengthValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/MinLengthValidatorTests/When_Validate_Called.cs
@@ -26,7 +26,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.MinLengthValidatorTests
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/MinWordCountValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/MinWordCountValidatorTests/When_Validate_Called.cs
@@ -26,7 +26,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.MinWordCountValidatorTest
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/MonthAndYearNotInFutureValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/MonthAndYearNotInFutureValidatorTests/When_Validate_Called.cs
@@ -24,7 +24,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.MonthAndYearNotInFutureVa
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/MonthAndYearTypeValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/MonthAndYearTypeValidatorTests/When_Validate_Called.cs
@@ -25,7 +25,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.MonthAndYearTypeValidator
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/MonthAndYearValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/MonthAndYearValidatorTests/When_Validate_Called.cs
@@ -26,7 +26,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.MonthAndYearValidatorTest
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/NumberTypeValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/NumberTypeValidatorTests/When_Validate_Called.cs
@@ -35,7 +35,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.NumberTypeValidatorTests
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input?.ToString(), QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{ input?.ToString()}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/NumberValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/NumberValidatorTests/When_Validate_Called.cs
@@ -35,7 +35,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.NumberValidatorTests
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input?.ToString(), QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{ input?.ToString()}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/RegexValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/RegexValidatorTests/When_Validate_Called.cs
@@ -25,7 +25,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.RegexValidatorTests
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/RequiredValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/RequiredValidatorTests/When_Validate_Called.cs
@@ -25,7 +25,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.RequiredValidatorTests
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application.UnitTests/Validators/UrlValidatorTests/When_Validate_Called.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/Validators/UrlValidatorTests/When_Validate_Called.cs
@@ -34,7 +34,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.Validators.UrlValidatorTests
             };
 
             var question = new Question { QuestionId = "Q1" };
-            var errors = validator.Validate(question, new Answer { Value = input, QuestionId = question.QuestionId });
+            var errors = validator.Validate(question, new Answer { Value = new []{input}, QuestionId = question.QuestionId });
 
             (errors.Count is 0).Should().Be(isValid);
         }

--- a/src/SFA.DAS.QnA.Application/Commands/AnswerValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Commands/AnswerValidator.cs
@@ -26,7 +26,7 @@ namespace SFA.DAS.QnA.Application.Commands
 
                 if (question.Input.Options == null) continue;
 
-                foreach (var option in question.Input.Options.Where(option => answerToThisQuestion?.Value == option.Value && option.FurtherQuestions != null))
+                foreach (var option in question.Input.Options.Where(option => option.FurtherQuestions != null && answerToThisQuestion?.Value[0] == option.Value))
                 {
                     foreach (var furtherQuestion in option.FurtherQuestions)
                     {
@@ -43,7 +43,7 @@ namespace SFA.DAS.QnA.Application.Commands
         {
             var validators = _validatorFactory.Build(question);
             
-            if (answerToThisQuestion is null || answerToThisQuestion.Value == "")
+            if (answerToThisQuestion is null || answerToThisQuestion.Value.Length == 0 || answerToThisQuestion.Value[0] == "")
             {
                 if (!validators.Any(v => v.GetType().Name.EndsWith("RequiredValidator"))) return;
                 

--- a/src/SFA.DAS.QnA.Application/Commands/Files/DeleteFile/DeleteFileRequest.cs
+++ b/src/SFA.DAS.QnA.Application/Commands/Files/DeleteFile/DeleteFileRequest.cs
@@ -74,7 +74,7 @@ namespace SFA.DAS.QnA.Application.Commands.Files.DeleteFile
             var container = await ContainerHelpers.GetContainer(_fileStorageConfig.Value.StorageConnectionString, _fileStorageConfig.Value.ContainerName);
             var directory = ContainerHelpers.GetDirectory(request.ApplicationId, section.SequenceId, request.SectionId, request.PageId, request.QuestionId, container);
 
-            var answer = page.PageOfAnswers.SingleOrDefault(poa => poa.Answers.Any(a => a.QuestionId == request.QuestionId && a.Value == request.FileName));
+            var answer = page.PageOfAnswers.SingleOrDefault(poa => poa.Answers.Any(a => a.QuestionId == request.QuestionId && a.Value[0] == request.FileName));
             if (answer is null)
             {
                 return new HandlerResponse<bool>(success:false, message:$"Question {request.QuestionId} on Page {request.PageId} in Application {request.ApplicationId} does not contain an upload named {request.FileName}.");

--- a/src/SFA.DAS.QnA.Application/Commands/Files/DownloadFile/DownloadFileHandler.cs
+++ b/src/SFA.DAS.QnA.Application/Commands/Files/DownloadFile/DownloadFileHandler.cs
@@ -67,7 +67,7 @@ namespace SFA.DAS.QnA.Application.Commands.Files.DownloadFile
             if (blobs.Count() == 1)
             {
                 var answer = page.PageOfAnswers.SelectMany(poa => poa.Answers).Single(a => a.QuestionId == request.QuestionId);
-                return await IndividualFile(answer.Value, cancellationToken, questionDirectory);
+                return await IndividualFile(answer.Value[0], cancellationToken, questionDirectory);
             }
 
             if (!blobs.Any()) return new HandlerResponse<DownloadFile>(success: false, message: $"Page {request.PageId} in Application {request.ApplicationId} does not contain any uploads.");
@@ -90,9 +90,9 @@ namespace SFA.DAS.QnA.Application.Commands.Files.DownloadFile
                     foreach (var answer in page.PageOfAnswers.SelectMany(poa => poa.Answers))
                     {
                         var questionDirectory = pageDirectory.GetDirectoryReference(answer.QuestionId.ToLower());
-                        var blobStream = await GetFileStream(cancellationToken, questionDirectory, answer.Value);
+                        var blobStream = await GetFileStream(cancellationToken, questionDirectory, answer.Value[0]);
 
-                        var zipEntry = zipArchive.CreateEntry(answer.Value);
+                        var zipEntry = zipArchive.CreateEntry(answer.Value[0]);
                         using (var entryStream = zipEntry.Open())
                         {
                             blobStream.Item1.CopyTo(entryStream);
@@ -127,9 +127,9 @@ namespace SFA.DAS.QnA.Application.Commands.Files.DownloadFile
             {
                 foreach (var answer in page.PageOfAnswers.SelectMany(poa => poa.Answers).Where(a => a.QuestionId == request.QuestionId))
                 {
-                    var blobStream = await GetFileStream(cancellationToken, directory, answer.Value);
+                    var blobStream = await GetFileStream(cancellationToken, directory, answer.Value[0]);
 
-                    var zipEntry = zipArchive.CreateEntry(answer.Value);
+                    var zipEntry = zipArchive.CreateEntry(answer.Value[0]);
                     using (var entryStream = zipEntry.Open())
                     {
                         blobStream.Item1.CopyTo(entryStream);
@@ -140,7 +140,7 @@ namespace SFA.DAS.QnA.Application.Commands.Files.DownloadFile
 
         private async Task<HandlerResponse<DownloadFile>> SpecifiedFile(DownloadFileRequest request, CancellationToken cancellationToken, Page page, CloudBlobDirectory directory)
         {
-            var answer = page.PageOfAnswers.SelectMany(poa => poa.Answers).SingleOrDefault(a => a.Value == request.FileName && a.QuestionId == request.QuestionId);
+            var answer = page.PageOfAnswers.SelectMany(poa => poa.Answers).SingleOrDefault(a => a.Value[0] == request.FileName && a.QuestionId == request.QuestionId);
             if (answer is null)
             {
                 return new HandlerResponse<DownloadFile>(success: false, message: $"Question {request.QuestionId} on Page {request.PageId} in Application {request.ApplicationId} does not contain an upload named {request.FileName}");

--- a/src/SFA.DAS.QnA.Application/Commands/Files/UploadFile/SubmitPageOfFilesHandler.cs
+++ b/src/SFA.DAS.QnA.Application/Commands/Files/UploadFile/SubmitPageOfFilesHandler.cs
@@ -50,7 +50,7 @@ namespace SFA.DAS.QnA.Application.Commands.Files.UploadFile
             var answersToValidate = new List<Answer>();
             foreach (var file in request.Files)
             {
-                var answer = new Answer() {QuestionId = file.Name, Value = file.FileName};
+                var answer = new Answer() {QuestionId = file.Name, Value = new[] {file.FileName}};
                 answersToValidate.Add(answer);
             }
             
@@ -98,7 +98,7 @@ namespace SFA.DAS.QnA.Application.Commands.Files.UploadFile
                     page.PageOfAnswers = new List<PageOfAnswers>();
                 }
 
-                var foundExistingOnPage = page.PageOfAnswers.SelectMany(a => a.Answers).Any(answer => answer.QuestionId == file.Name && answer.Value == file.FileName);
+                var foundExistingOnPage = page.PageOfAnswers.SelectMany(a => a.Answers).Any(answer => answer.QuestionId == file.Name && answer.Value[0] == file.FileName);
                 
                 if (!foundExistingOnPage)
                 {
@@ -107,7 +107,7 @@ namespace SFA.DAS.QnA.Application.Commands.Files.UploadFile
                         new Answer()
                         {
                             QuestionId = file.Name,
-                            Value = file.FileName
+                            Value = new [] { file.FileName }
                         }
                     }});
                 }
@@ -145,13 +145,15 @@ namespace SFA.DAS.QnA.Application.Commands.Files.UploadFile
         {
             if (string.IsNullOrWhiteSpace(question.QuestionTag)) return;
 
+            var answer = answers.Single(a => a.QuestionId == question.QuestionId);
+            
             if (applicationData.ContainsKey(question.QuestionTag))
             {
-                applicationData[question.QuestionTag] = answers.Single(a => a.QuestionId == question.QuestionId).Value;
+                applicationData[question.QuestionTag] = answer.Value.Length == 1 ? (JToken) answer.Value[0] : new JValue(answer.Value[0]);
             }
             else
             {
-                applicationData.Add(question.QuestionTag, new JValue(answers.Single(a => a.QuestionId == question.QuestionId).Value));
+                applicationData.Add(question.QuestionTag, answer.Value.Length == 1 ? new JValue(answer.Value[0]) : new JValue(answer.Value));
             }
         }
     }

--- a/src/SFA.DAS.QnA.Application/Commands/SetPageAnswers/SetAnswersBase.cs
+++ b/src/SFA.DAS.QnA.Application/Commands/SetPageAnswers/SetAnswersBase.cs
@@ -47,7 +47,7 @@ namespace SFA.DAS.QnA.Application.Commands.SetPageAnswers
                         else
                         {
                             var answer = answers.FirstOrDefault(a => a.QuestionId == condition.QuestionId);
-                            if (answer == null || answer.QuestionId != condition.QuestionId || answer.Value != condition.MustEqual)
+                            if (answer == null || answer.QuestionId != condition.QuestionId || answer.Value[0] != condition.MustEqual)
                             {
                                 someConditionsNotSatisfied = true;
                             }

--- a/src/SFA.DAS.QnA.Application/Commands/SetPageAnswers/SetPageAnswersHandler.cs
+++ b/src/SFA.DAS.QnA.Application/Commands/SetPageAnswers/SetPageAnswersHandler.cs
@@ -87,13 +87,15 @@ namespace SFA.DAS.QnA.Application.Commands.SetPageAnswers
         {
             if (string.IsNullOrWhiteSpace(question.QuestionTag)) return;
 
+            var answer = answers.Single(a => a.QuestionId == question.QuestionId);
+            
             if (applicationData.ContainsKey(question.QuestionTag))
             {
-                applicationData[question.QuestionTag] = answers.Single(a => a.QuestionId == question.QuestionId).Value;
+                applicationData[question.QuestionTag] = answer.Value.Length == 1 ? (JToken) answer.Value[0] : new JValue(answer.Value[0]);
             }
             else
             {
-                applicationData.Add(question.QuestionTag, new JValue(answers.Single(a => a.QuestionId == question.QuestionId).Value));
+                applicationData.Add(question.QuestionTag, answer.Value.Length == 1 ? new JValue(answer.Value[0]) : new JValue(answer.Value));
             }
         }
 

--- a/src/SFA.DAS.QnA.Application/Commands/SetPageAnswers/SetPageAnswersHandler.cs
+++ b/src/SFA.DAS.QnA.Application/Commands/SetPageAnswers/SetPageAnswersHandler.cs
@@ -95,7 +95,7 @@ namespace SFA.DAS.QnA.Application.Commands.SetPageAnswers
             }
             else
             {
-                applicationData.Add(question.QuestionTag, answer.Value.Length == 1 ? new JValue(answer.Value[0]) : new JValue(answer.Value));
+                applicationData.Add(question.QuestionTag, answer.Value.Length == 1 ? new JValue(answer.Value[0]) : JToken.FromObject(answer.Value));
             }
         }
 

--- a/src/SFA.DAS.QnA.Application/Validators/AddressBuildingAndStreetRequiredValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/AddressBuildingAndStreetRequiredValidator.cs
@@ -10,7 +10,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (!string.IsNullOrEmpty(text))
             {

--- a/src/SFA.DAS.QnA.Application/Validators/AddressPostcodeRequiredValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/AddressPostcodeRequiredValidator.cs
@@ -10,7 +10,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (!string.IsNullOrEmpty(text))
             {

--- a/src/SFA.DAS.QnA.Application/Validators/AddressTownOrCityRequiredValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/AddressTownOrCityRequiredValidator.cs
@@ -10,7 +10,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (!string.IsNullOrEmpty(text))
             {

--- a/src/SFA.DAS.QnA.Application/Validators/ComplexRadioTypeValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/ComplexRadioTypeValidator.cs
@@ -15,7 +15,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (!string.IsNullOrEmpty(text))
             {

--- a/src/SFA.DAS.QnA.Application/Validators/DateNotInFutureValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/DateNotInFutureValidator.cs
@@ -12,8 +12,8 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
-            var dateParts = answer?.Value.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
+            var text = answer?.Value?[0].Trim();
+            var dateParts = answer?.Value[0].Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             if (!string.IsNullOrEmpty(text) && dateParts != null && dateParts.Length == 3)
             {

--- a/src/SFA.DAS.QnA.Application/Validators/DateTypeValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/DateTypeValidator.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
             var dateParts = text?.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             if (string.IsNullOrEmpty(text) || dateParts is null || dateParts.Length != 3)

--- a/src/SFA.DAS.QnA.Application/Validators/DateValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/DateValidator.cs
@@ -12,7 +12,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
             var dateParts = text?.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             if (string.IsNullOrEmpty(text) || dateParts is null || dateParts.Length != 3)

--- a/src/SFA.DAS.QnA.Application/Validators/EmailTypeValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/EmailTypeValidator.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (!string.IsNullOrEmpty(text) && !IsValidEmail(text))
             {

--- a/src/SFA.DAS.QnA.Application/Validators/EmailValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/EmailValidator.cs
@@ -12,7 +12,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (!string.IsNullOrEmpty(text) && !IsValidEmail(text))
             {

--- a/src/SFA.DAS.QnA.Application/Validators/FileTypeValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/FileTypeValidator.cs
@@ -11,7 +11,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             var allowedExtension = ValidationDefinition.Value?.ToString().Split(",", StringSplitOptions.RemoveEmptyEntries)[0];
 

--- a/src/SFA.DAS.QnA.Application/Validators/MaxLengthValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/MaxLengthValidator.cs
@@ -10,7 +10,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (!string.IsNullOrEmpty(text) && text.Length > (long)ValidationDefinition.Value)
             {

--- a/src/SFA.DAS.QnA.Application/Validators/MaxWordCountValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/MaxWordCountValidator.cs
@@ -11,7 +11,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (!string.IsNullOrEmpty(text))
             {

--- a/src/SFA.DAS.QnA.Application/Validators/MinLengthValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/MinLengthValidator.cs
@@ -10,7 +10,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (!string.IsNullOrEmpty(text) && text.Length < (long)ValidationDefinition.Value)
             {

--- a/src/SFA.DAS.QnA.Application/Validators/MinWordCountValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/MinWordCountValidator.cs
@@ -11,7 +11,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (!string.IsNullOrEmpty(text))
             {

--- a/src/SFA.DAS.QnA.Application/Validators/MonthAndYearNotInFutureValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/MonthAndYearNotInFutureValidator.cs
@@ -12,8 +12,8 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
-            var dateParts = answer?.Value.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
+            var text = answer?.Value?[0].Trim();
+            var dateParts = answer?.Value[0].Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             if (!string.IsNullOrEmpty(text) && dateParts != null && dateParts.Length == 2)
             {

--- a/src/SFA.DAS.QnA.Application/Validators/MonthAndYearTypeValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/MonthAndYearTypeValidator.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
             var dateParts = text?.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             if (string.IsNullOrEmpty(text) || dateParts is null || dateParts.Length != 2)

--- a/src/SFA.DAS.QnA.Application/Validators/MonthAndYearValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/MonthAndYearValidator.cs
@@ -12,7 +12,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
             var dateParts = text?.Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries);
 
             if (string.IsNullOrEmpty(text) || dateParts is null || dateParts.Length != 2)

--- a/src/SFA.DAS.QnA.Application/Validators/NumberTypeValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/NumberTypeValidator.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (!string.IsNullOrEmpty(text) && !IsValidNumber(text))
             {

--- a/src/SFA.DAS.QnA.Application/Validators/NumberValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/NumberValidator.cs
@@ -10,7 +10,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (!string.IsNullOrEmpty(text) && !IsValidNumber(text))
             {

--- a/src/SFA.DAS.QnA.Application/Validators/RegexValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/RegexValidator.cs
@@ -12,7 +12,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (!string.IsNullOrEmpty(text) && !IsValidRegexMatch(text, ValidationDefinition.Value.ToString()))
             {

--- a/src/SFA.DAS.QnA.Application/Validators/RegisteredCharityNumberValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/RegisteredCharityNumberValidator.cs
@@ -12,7 +12,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (!string.IsNullOrEmpty(text) && !IsValidRegisteredCharityNumber(text))
             {

--- a/src/SFA.DAS.QnA.Application/Validators/RequiredValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/RequiredValidator.cs
@@ -10,7 +10,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (string.IsNullOrEmpty(text))
             {

--- a/src/SFA.DAS.QnA.Application/Validators/UrlValidator.cs
+++ b/src/SFA.DAS.QnA.Application/Validators/UrlValidator.cs
@@ -12,7 +12,7 @@ namespace SFA.DAS.QnA.Application.Validators
         {
             var errors = new List<KeyValuePair<string, string>>();
 
-            var text = answer?.Value?.Trim();
+            var text = answer?.Value?[0].Trim();
 
             if (!string.IsNullOrEmpty(text) && !IsValidUrl(text))
             {


### PR DESCRIPTION
Answer.Value is now a string[] and all code now checks for Value[0].  Calling client code needs to be changed to POST an array of the value instead of the value.

Condition class now has a Contains property.  This will be used to check a list of answer values for a value to match.  It's not used.... yet.