### PR TITLE
Update pages when QuestionTag is updated

### DIFF
--- a/src/SFA.DAS.QnA.Application/Commands/SetPageAnswers/SetAnswersBase.cs
+++ b/src/SFA.DAS.QnA.Application/Commands/SetPageAnswers/SetAnswersBase.cs
@@ -266,7 +266,7 @@ namespace SFA.DAS.QnA.Application.Commands.SetPageAnswers
             }
         }
 
-        private void DeactivateDependentPages(string branchingPageId, QnAData qnaData, Page page, Next chosenAction, bool subPages = false)
+        protected void DeactivateDependentPages(string branchingPageId, QnAData qnaData, Page page, Next chosenAction, bool subPages = false)
         {
             foreach (var nextAction in page.Next.Where(n => n != chosenAction || subPages))
             {
@@ -289,7 +289,7 @@ namespace SFA.DAS.QnA.Application.Commands.SetPageAnswers
             }
         }
 
-        private void ActivateDependentPages(Next next, string branchingPageId, QnAData qnaData)
+        protected void ActivateDependentPages(Next next, string branchingPageId, QnAData qnaData)
         {
             if (next.Action != "NextPage") return;
 


### PR DESCRIPTION
This code will update the status of all affected pages when a QuestionTag is updated.

It's important to note that other pages within different sections of the application may depend on that answers
Example:
Do you have a website = Yes/No
-- What is the URL to your complaints policy?