### PR TITLE
Changed the storagePrimaryEndpointsBlob output to be a variable

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -79,7 +79,8 @@
             {
                 "name": "projects"
             }
-        ]
+        ],
+        "storagePrimaryEndpointsBlob": "[concat('https://', variables('storageAccountName'), '.blob.core.windows.net')]"
     },
     "resources": [
         {
@@ -315,7 +316,7 @@
         },
         "StoragePrimaryEndpointsBlob": {
             "type": "string",
-            "value": "[reference('storage-account').outputs.storagePrimaryEndpointsBlob.value]"
+            "value": "[variables('storagePrimaryEndpointsBlob')]"
         }
     }
 }


### PR DESCRIPTION
As per `DASD-7392` the output referencing the `storagePrimaryEndpointsBlob` value includes the blob URL with a trailing '/' which no longer works for bulk insert and external data source:

```
[reference('storage-account').outputs.storagePrimaryEndpointsBlob.value
```
It results in the following error:

```
Bad or inaccessible location specified in external data source "BlobStorage".
```

To remove the trailing '/' from the output I've created a new variable to concat the `storageAccountName` variable inside the standard URL format for blob primary endpoint.

This should change the output `StoragePrimaryEndpointsBlob` from:

`https://<storageAccountName>.blob.core.windows.net/`

to 

`https://<storageAccountName>.blob.core.windows.net`