### PR TITLE
APR-1476 - QnA Service -  GetQuestionTag – JSON NULL value cannot be casted to string

### DIFF
--- a/src/SFA.DAS.QnA.Api/Controllers/ApplicationDataController.cs
+++ b/src/SFA.DAS.QnA.Api/Controllers/ApplicationDataController.cs
@@ -58,12 +58,7 @@ namespace SFA.DAS.QnA.Api.Controllers
 
             if (!applicationDataResponse.Success) return NotFound(new NotFoundError(applicationDataResponse.Message));
 
-            if (!string.IsNullOrEmpty(applicationDataResponse?.Value))
-            {
-                return applicationDataResponse.Value;
-            }
-
-            return BadRequest(new BadRequestError("QuestionTag value is null"));
+            return applicationDataResponse?.Value;
         }
 
         /// <summary>

--- a/src/SFA.DAS.QnA.Application/Queries/ApplicationData/GetApplicationData/GetQuestionTagDataHandler.cs
+++ b/src/SFA.DAS.QnA.Application/Queries/ApplicationData/GetApplicationData/GetQuestionTagDataHandler.cs
@@ -35,15 +35,8 @@ namespace SFA.DAS.QnA.Application.Queries.ApplicationData.GetApplicationData
 
                 try
                 {
-                    var questionTagValue = (string)command.ExecuteScalar();
-                    if (string.IsNullOrEmpty(questionTagValue))
-                    {
-                        return new HandlerResponse<string>(success: false, message: "QuestionTag does not have a value.");
-                    }
-                    else
-                    {
-                        return new HandlerResponse<string>(questionTagValue);
-                    }
+                    var questionTagValue = command.ExecuteScalar();
+                    return new HandlerResponse<string>(Convert.ToString(questionTagValue));
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
SFA.DAS.QnA.Application\Queries\ApplicationData\GetApplicationData\GetQuestionTagDataHandler.cs
It seems that
var questionTagValue = (string)command.ExecuteScalar();
cannot cast NULL to empty string and it raises exception.
So, I needed to change it to
var questionTagValue = command.ExecuteScalar();
return new HandlerResponse<string>(Convert.ToString(questionTagValue));
which works fine.
