### PR TITLE
APR-1845 - File validation should be done using question input validations

### DIFF
--- a/src/SFA.DAS.QnA.Api.UnitTests/FileControllerTests/When_download_file_or_zip_of_files_is_called.cs
+++ b/src/SFA.DAS.QnA.Api.UnitTests/FileControllerTests/When_download_file_or_zip_of_files_is_called.cs
@@ -19,7 +19,6 @@ namespace SFA.DAS.QnA.Api.UnitTests.FileControllerTests
     {
         private ILogger<FileController> _logger;
         private IMediator _mediator;
-        private IHttpContextAccessor _httpContextAccessor;
         private FileController _fileController;
 
         [SetUp]
@@ -27,8 +26,7 @@ namespace SFA.DAS.QnA.Api.UnitTests.FileControllerTests
         {
             _logger = Substitute.For<ILogger<FileController>>(); ;
             _mediator = Substitute.For<IMediator>();
-            _httpContextAccessor = Substitute.For<IHttpContextAccessor>();
-            _fileController = new FileController(_logger, _mediator, _httpContextAccessor);
+            _fileController = new FileController(_logger, _mediator);
         }
 
         [Test]

--- a/src/SFA.DAS.QnA.Api.UnitTests/FileControllerTests/When_upload_is_called.cs
+++ b/src/SFA.DAS.QnA.Api.UnitTests/FileControllerTests/When_upload_is_called.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using NSubstitute;
+using NUnit.Framework;
+using SFA.DAS.QnA.Api.Controllers;
+using SFA.DAS.QnA.Api.Types;
+using SFA.DAS.QnA.Application.Commands.Files.UploadFile;
+
+namespace SFA.DAS.QnA.Api.UnitTests.FileControllerTests
+{
+    [TestFixture]
+    public class When_upload_is_called
+    {
+        private ILogger<FileController> _logger;
+        private IMediator _mediator;
+        private FileController _fileController;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _logger = Substitute.For<ILogger<FileController>>();
+            _mediator = Substitute.For<IMediator>();
+            _fileController = new FileController(_logger, _mediator)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = new DefaultHttpContext()
+                }
+            };
+        }
+
+        [Test]
+        public async Task Then_bad_request_returned_if_fails_to_upload()
+        {
+            var applicationId = Guid.NewGuid();
+            var sectionId = Guid.NewGuid();
+            var pageId = "pageId";
+            var failMessage = "failed";
+
+            _mediator.Send(Arg.Any<SubmitPageOfFilesRequest>()).Returns(new HandlerResponse<SetPageAnswersResponse>(false, failMessage));
+
+            var result = await _fileController.Upload(applicationId, sectionId, pageId);
+
+            result.Result.Should().BeOfType<BadRequestObjectResult>();
+        }
+
+        [Test]
+        public async Task Then_success_returned_if_uploaded_successfully()
+        {
+            var applicationId = Guid.NewGuid();
+            var sectionId = Guid.NewGuid();
+            var pageId = "pageId";
+            var nextAction = "nextAction";
+            var nextActionId = "nextActionId";
+
+            var response = new SetPageAnswersResponse(nextAction, nextActionId);
+
+            _mediator.Send(Arg.Any<SubmitPageOfFilesRequest>()).Returns(new HandlerResponse<SetPageAnswersResponse>(response));
+
+            _fileController.HttpContext.Request.Form = new FormCollection(new Dictionary<string, StringValues>());
+            var result = await _fileController.Upload(applicationId, sectionId, pageId);
+
+            result.Value.Should().BeOfType<SetPageAnswersResponse>();
+            result.Value.ValidationPassed.Should().BeTrue();
+            result.Value.NextAction.Should().Be(nextAction);
+            result.Value.NextActionId.Should().Be(nextActionId);
+        }
+    }
+}

--- a/src/SFA.DAS.QnA.Api/Controllers/FileController.cs
+++ b/src/SFA.DAS.QnA.Api/Controllers/FileController.cs
@@ -18,19 +18,27 @@ namespace SFA.DAS.QnA.Api.Controllers
     {
         private readonly ILogger<FileController> _logger;
         private readonly IMediator _mediator;
-        private readonly IHttpContextAccessor _contextAccessor;
 
-        public FileController(ILogger<FileController> logger, IMediator mediator, IHttpContextAccessor contextAccessor)
+        public FileController(ILogger<FileController> logger, IMediator mediator)
         {
             _logger = logger;
             _mediator = mediator;
-            _contextAccessor = contextAccessor;
         }
         
         [HttpPost("{applicationId}/sections/{sectionId}/pages/{pageId}/upload")]
         public async Task<ActionResult<SetPageAnswersResponse>> Upload(Guid applicationId, Guid sectionId, string pageId)
         {
-            var uploadResult = await _mediator.Send(new SubmitPageOfFilesRequest(applicationId, sectionId, pageId, _contextAccessor.HttpContext.Request.Form.Files));
+            IFormFileCollection files;
+            try
+            {
+                files = HttpContext.Request.Form.Files;
+            }
+            catch
+            {
+                files = null;
+            }
+
+            var uploadResult = await _mediator.Send(new SubmitPageOfFilesRequest(applicationId, sectionId, pageId, files));
 
             if (!uploadResult.Success)
             {

--- a/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SubmitPageOfFilesHandlerTests/SubmitPageOfFilesTestBase.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SubmitPageOfFilesHandlerTests/SubmitPageOfFilesTestBase.cs
@@ -67,7 +67,7 @@ namespace SFA.DAS.QnA.Application.UnitTests.CommandsTests.SubmitPageOfFilesHandl
                             PageId = "1",
                             Questions = new List<Question>{new Question(){QuestionId = "Q1", Input = new Input { Type = "FileUpload" } }},
                             PageOfAnswers = new List<PageOfAnswers>(),
-                            Next = new List<Next>(),
+                            Next = new List<Next>{ new Next { } },
                             Active = true
                         }
                     }

--- a/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SubmitPageOfFilesHandlerTests/When_files_specified_is_empty.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SubmitPageOfFilesHandlerTests/When_files_specified_is_empty.cs
@@ -10,6 +10,9 @@ namespace SFA.DAS.QnA.Application.UnitTests.CommandsTests.SubmitPageOfFilesHandl
     public class When_files_specified_is_empty : SubmitPageOfFilesTestBase
     {
         [Test]
+#if (!DEBUG)
+        [Ignore("Must be tested on local DEV machine as it uses local Azure storage")]
+#endif
         public async Task Then_validation_passes()
         {
             var files = new FormFileCollection();

--- a/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SubmitPageOfFilesHandlerTests/When_files_specified_is_empty.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SubmitPageOfFilesHandlerTests/When_files_specified_is_empty.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http.Internal;
+using NUnit.Framework;
+using SFA.DAS.QnA.Application.Commands.Files.UploadFile;
+
+namespace SFA.DAS.QnA.Application.UnitTests.CommandsTests.SubmitPageOfFilesHandlerTests
+{
+    public class When_files_specified_is_empty : SubmitPageOfFilesTestBase
+    {
+        [Test]
+        public async Task Then_validation_passes()
+        {
+            var files = new FormFileCollection();
+            var response = await Handler.Handle(new SubmitPageOfFilesRequest(ApplicationId, SectionId, "1", files), CancellationToken.None);
+
+            response.Value.ValidationPassed.Should().BeTrue();
+        }
+    }
+}

--- a/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SubmitPageOfFilesHandlerTests/When_files_specified_is_null.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SubmitPageOfFilesHandlerTests/When_files_specified_is_null.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using NUnit.Framework;
+using SFA.DAS.QnA.Application.Commands.Files.UploadFile;
+
+namespace SFA.DAS.QnA.Application.UnitTests.CommandsTests.SubmitPageOfFilesHandlerTests
+{
+    public class When_files_specified_is_null : SubmitPageOfFilesTestBase
+    {
+        [Test]
+        public async Task Then_return_no_files_specified_message()
+        {
+            var response = await Handler.Handle(new SubmitPageOfFilesRequest(ApplicationId, SectionId, "1", null), CancellationToken.None);
+
+            response.Success.Should().BeFalse();
+            response.Message.Should().Be("No files specified.");
+        }
+    }
+}

--- a/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SubmitPageOfFilesHandlerTests/When_files_specified_is_null.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SubmitPageOfFilesHandlerTests/When_files_specified_is_null.cs
@@ -9,6 +9,9 @@ namespace SFA.DAS.QnA.Application.UnitTests.CommandsTests.SubmitPageOfFilesHandl
     public class When_files_specified_is_null : SubmitPageOfFilesTestBase
     {
         [Test]
+#if (!DEBUG)
+        [Ignore("Must be tested on local DEV machine as it uses local Azure storage")]
+#endif
         public async Task Then_return_no_files_specified_message()
         {
             var response = await Handler.Handle(new SubmitPageOfFilesRequest(ApplicationId, SectionId, "1", null), CancellationToken.None);

--- a/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SubmitPageOfFilesHandlerTests/When_files_specified_is_null.cs
+++ b/src/SFA.DAS.QnA.Application.UnitTests/CommandsTests/SubmitPageOfFilesHandlerTests/When_files_specified_is_null.cs
@@ -9,9 +9,6 @@ namespace SFA.DAS.QnA.Application.UnitTests.CommandsTests.SubmitPageOfFilesHandl
     public class When_files_specified_is_null : SubmitPageOfFilesTestBase
     {
         [Test]
-#if (!DEBUG)
-        [Ignore("Must be tested on local DEV machine as it uses local Azure storage")]
-#endif
         public async Task Then_return_no_files_specified_message()
         {
             var response = await Handler.Handle(new SubmitPageOfFilesRequest(ApplicationId, SectionId, "1", null), CancellationToken.None);

--- a/src/SFA.DAS.QnA.Application/Commands/Files/UploadFile/SubmitPageOfFilesHandler.cs
+++ b/src/SFA.DAS.QnA.Application/Commands/Files/UploadFile/SubmitPageOfFilesHandler.cs
@@ -63,7 +63,7 @@ namespace SFA.DAS.QnA.Application.Commands.Files.UploadFile
             {
                 return new HandlerResponse<SetPageAnswersResponse>(success: false, message: "Cannot find requested page.");
             }
-            else if (request.Files is null || !request.Files.Any())
+            else if (request.Files is null)
             {
                 return new HandlerResponse<SetPageAnswersResponse>(success: false, message: "No files specified.");
             }
@@ -191,7 +191,7 @@ namespace SFA.DAS.QnA.Application.Commands.Files.UploadFile
                     }
 
                     application.ApplicationData = applicationData.ToString(Formatting.None);
-                    
+
                     SetStatusOfAllPagesBasedOnUpdatedQuestionTags(application, questionTagsWhichHaveBeenUpdated);
                     _tagProcessingService.ClearDeactivatedTags(application.Id, request.SectionId);
                 }


### PR DESCRIPTION
If no files were specified when saving a FileUpload question then it returns a generic error message rather than the one in the Required validator (if present)