### PR TITLE
SV-Fix to allow multiple workflows per project (as designed)

### DIFF
--- a/src/SFA.DAS.QnA.Database/projects/Inject-projects.sql
+++ b/src/SFA.DAS.QnA.Database/projects/Inject-projects.sql
@@ -86,7 +86,7 @@ BEGIN
 		ELSE
 		BEGIN
 			SET @ProjectLocation = @ProjectLocation + 'projects\' + @ProjectDef +'\';
-			PRINT 'Loading from File Storage'+@ProjectLocation;
+			PRINT 'Loading from File Storage: '+@ProjectLocation;
 		END
 	
 		-- inject project
@@ -111,19 +111,23 @@ BEGIN
             
         -- load the Workflows
         SET @WorkflowIndex = 0;
-        -- loop  thorugh the workflows
+        -- loop  through the workflows
         WHILE @WorkflowIndex >= 0
         BEGIN
             -- get the first/next workflow from project.
-            PRINT 'Get Workflow '+RTRIM(CONVERT(char,@WorkflowIndex))+' for project '+@ProjectName
+            PRINT 'Getting Workflow at index '+RTRIM(CONVERT(char,@WorkflowIndex))+' for project '+@ProjectName
             SELECT @Workflows = JSON_QUERY(@JSON,'$.Workflows['+RTRIM(convert(char,@WorkflowIndex))+']');
 
             IF @Workflows IS NULL
+                BEGIN
+					PRINT 'Nothing found'
                     BREAK;
-                    
-            PRINT 'Configure Workflow '+RTRIM(CONVERT(char,@WorkflowIndex))            
+				END
+                                
             -- extract workflow(s)
             SELECT @WorkflowDescription = JSON_VALUE(@Workflows,'$.Description'), @WorkflowVersion = JSON_VALUE(@Workflows,'$.Version'), @WorkflowType = JSON_VALUE(@Workflows,'$.Type');
+			
+            PRINT 'Configuring Workflow '+RTRIM(CONVERT(char,@WorkflowDescription))+' '+RTRIM(CONVERT(char,@WorkflowVersion))
 
             -- check if project exists
             SELECT @ProjectExists = COUNT(*) FROM projects WHERE Name = @ProjectName


### PR DESCRIPTION
This fix loops around for one for more workflows in the project.json files.
Having multiple workflows per project was as designed, but the initial version of the inject-projects.sql had been hard-coded for just one.